### PR TITLE
Make streams usable for A2A work

### DIFF
--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -1395,6 +1395,14 @@ export interface Stream extends BaseMetadata {
    */
   streamId: string;
 
+  /**
+   * The type of messages sent on this stream.
+   * - All methods and notifications may be sent on the default `generic` stream.
+   * - A `chat` stream represents a language model conversation and can
+   *   additionally involve `notifications/chat/message` notifications.
+   */
+  kind?: "generic" | "chat";
+
   resumeInterval?: {
     /**
      * The minimum number of seconds a client should wait before resuming
@@ -1489,6 +1497,20 @@ export interface StreamEndNotification extends Notification {
   }
 }
 
+/**
+ * Indicates a chat message was sent. This notification type may only be sent
+ * on Streams marked with the `chat` type.
+ */
+export interface ChatMessageNotification extends Notification {
+  method: 'notifications/chat/message';
+  params: {
+    /**
+     * Message that was sent on the stream.
+     */
+    message: SamplingMessage;
+  }
+}
+
 
 /* Client messages */
 export type ClientRequest =
@@ -1536,7 +1558,8 @@ export type ServerNotification =
   | ToolListChangedNotification
   | PromptListChangedNotification
   | StreamCreateNotification
-  | StreamEndNotification;
+  | StreamEndNotification
+  | ChatMessageNotification;
 
 export type ServerResult =
   | EmptyResult


### PR DESCRIPTION
This builds on the initial implementation of streams https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/543.\
With this and additional existing PRs to flesh out `SamplingMessage`,
agent-to-agent flows become feasible. Consider the following cases:

1. A tool call spawns an A2A subtask. The MCP server creates a `chat`
   type stream, upon which `notifications/chat/message` messages are
   sent as agents interact. If user interaction is needed, the existing
   elicitation capabilities can be used.
2. A user experiences a network interruption. Usual stream resumption
   can be used in this case.
3. A user moves to a new machine and wants to continue their A2A flows.
   An authenticated MCP server may simply notify the client of all
   ongoing streams and they may be `stream/resume`'d.