### PR TITLE
Use `stream/poll` and `stream/poll/all` for stream status

### DIFF
--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -1463,9 +1463,14 @@ export interface StreamPollRequest extends Request {
 }
 
 /**
- * A response to the `stream/poll` request.
+ * The status of a stream.
  */
-export interface StreamPollResult extends Result {
+export interface StreamStatus {
+  /**
+   * The ID of the stream.
+   */
+  streamId: string;
+
   /**
    * The current status of the stream.
    */
@@ -1485,6 +1490,30 @@ export interface StreamPollResult extends Result {
    * Whether the stream's pending messages include an error result.
    */
   hasError: boolean;
+}
+
+/**
+ * A response to a `stream/poll` request.
+ */
+export interface StreamPollResult extends Result, StreamStatus {
+}
+
+/**
+ * A request from the client to the server to check the status of all current
+ * streams.
+ *
+ * The server SHOULD reset each stream's abandonment timer when responding to
+ * this request.
+ */
+export interface StreamPollAllRequest extends Request {
+  method: "stream/poll/all";
+}
+
+/**
+ * A response to a `stream/poll/all` request.
+ */
+export interface StreamPollAllResult extends Result {
+  statuses: StreamStatus[];
 }
 
 export interface StreamEndNotification extends Notification {

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -1464,7 +1464,7 @@ export interface StreamPollRequest extends Request {
 /**
  * A response to the `stream/poll` request.
  */
-export interface StreamPollResponse extends Response {
+export interface StreamPollResult extends Result {
   /**
    * Messages and notifications to be delivered to the client on the stream.
    * The client should respond to any pending requests found in this list.

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -1442,11 +1442,12 @@ export interface StreamResumeRequest extends Request {
     streamId: string;
   };
 }
+
 /**
- * A request from the client to the server to retrieve any new messages from
- * the stream. The server MUST include all unsent messages to the client
- * when this method is called. If the stream is closed, the server MUST append
- * a `notifications/stream/end` notification to the end of the resulting messages.
+ * A request from the client to the server to check the status of a stream.
+ *
+ * The server SHOULD reset the stream's abandonment timer when responding to
+ * this request.
  */
 export interface StreamPollRequest extends Request {
   method: "stream/poll";
@@ -1466,15 +1467,24 @@ export interface StreamPollRequest extends Request {
  */
 export interface StreamPollResult extends Result {
   /**
-   * Messages and notifications to be delivered to the client on the stream.
-   * The client should respond to any pending requests found in this list.
+   * The current status of the stream.
    */
-  messages: (ServerNotification | ServerRequest)[];
+  status: "live" | "completed" | "abandoned";
 
   /**
-   * Optionally-updated properties for the stream.
+   * Whether the stream has pending messages.
    */
-  stream?: String;
+  pendingMessages: boolean;
+
+  /**
+   * Whether the stream's pending messages include a server-sent request.
+   */
+  hasRequest: boolean;
+
+  /**
+   * Whether the stream's pending messages include an error result.
+   */
+  hasError: boolean;
 }
 
 export interface StreamEndNotification extends Notification {


### PR DESCRIPTION
This repurposes `stream/poll` to check a stream's status, and adds `stream/poll/all` to check the status of all streams.  `stream/poll/all` can be used to accomplish point 3 of https://github.com/connor4312/mcp-spec/pull/1.

I'm not sure if the `"abandoned"` is necessary.  If a stream is abandoned, servers may just want to free all associated resources.  In which case, there may be no record of the stream, and `stream/poll` would return an error instead.

Also, the status names are bikesheddable (e.g. "open" and "closed" vs "live" and "completed").  Though it would be nice if the name for "completed" did not clash too much with "resume", because `stream/resume` is used to fetch messages of completed stream.